### PR TITLE
Improve HDR post-processing

### DIFF
--- a/hdr_gui.py
+++ b/hdr_gui.py
@@ -9,13 +9,39 @@ from find_and_merge_aeb import (
     create_hdr,
 )
 
-def tonemap_mantiuk(hdr_image):
+def get_medium_exposure_image(images, exposure_times):
+    if not images or not exposure_times:
+        return None
+    pairs = sorted(zip(exposure_times, images), key=lambda x: x[0])
+    _, sorted_images = zip(*pairs)
+    return sorted_images[len(sorted_images) // 2]
+
+
+def enhance_image(img, reference=None):
+    hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV).astype(np.float32)
+    hsv[..., 1] = np.clip(hsv[..., 1] * 1.3, 0, 255)
+    img = cv2.cvtColor(hsv.astype(np.uint8), cv2.COLOR_HSV2BGR)
+
+    lab = cv2.cvtColor(img, cv2.COLOR_BGR2LAB)
+    l, a, b = cv2.split(lab)
+    clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
+    l = clahe.apply(l)
+    img = cv2.cvtColor(cv2.merge((l, a, b)), cv2.COLOR_LAB2BGR)
+
+    if reference is not None:
+        ref = cv2.resize(reference, (img.shape[1], img.shape[0]))
+        img = cv2.addWeighted(img.astype(np.float32), 0.7, ref.astype(np.float32), 0.3, 0)
+        img = img.astype(np.uint8)
+    return img
+
+
+def tonemap_mantiuk(hdr_image, reference_image=None):
     tonemap = cv2.createTonemapMantiuk()
-    tonemap.setSaturation(1.2)
+    tonemap.setSaturation(1.6)
     tonemap.setScale(0.7)
     ldr = tonemap.process(hdr_image.copy())
     ldr_8bit = np.clip(ldr * 255, 0, 255).astype('uint8')
-    return ldr_8bit
+    return enhance_image(ldr_8bit, reference_image)
 
 class HDRGui:
     def __init__(self):
@@ -53,7 +79,8 @@ class HDRGui:
             return
         images = load_images(aeb_images)
         self.hdr_image = create_hdr(images, exposure_times)
-        self.ldr_image = tonemap_mantiuk(self.hdr_image)
+        ref_image = get_medium_exposure_image(images, exposure_times)
+        self.ldr_image = tonemap_mantiuk(self.hdr_image, ref_image)
         self.display_image(self.ldr_image)
         dpg.configure_item(self.save_btn, enabled=True)
 

--- a/process_uploads.py
+++ b/process_uploads.py
@@ -8,13 +8,39 @@ from find_and_merge_aeb import (
     create_hdr,
 )
 
-def tonemap_mantiuk(hdr_image):
+def get_medium_exposure_image(images, exposure_times):
+    if not images or not exposure_times:
+        return None
+    pairs = sorted(zip(exposure_times, images), key=lambda x: x[0])
+    _, sorted_images = zip(*pairs)
+    return sorted_images[len(sorted_images) // 2]
+
+
+def enhance_image(img, reference=None):
+    hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV).astype(np.float32)
+    hsv[..., 1] = np.clip(hsv[..., 1] * 1.3, 0, 255)
+    img = cv2.cvtColor(hsv.astype(np.uint8), cv2.COLOR_HSV2BGR)
+
+    lab = cv2.cvtColor(img, cv2.COLOR_BGR2LAB)
+    l, a, b = cv2.split(lab)
+    clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
+    l = clahe.apply(l)
+    img = cv2.cvtColor(cv2.merge((l, a, b)), cv2.COLOR_LAB2BGR)
+
+    if reference is not None:
+        ref = cv2.resize(reference, (img.shape[1], img.shape[0]))
+        img = cv2.addWeighted(img.astype(np.float32), 0.7, ref.astype(np.float32), 0.3, 0)
+        img = img.astype(np.uint8)
+    return img
+
+
+def tonemap_mantiuk(hdr_image, reference_image=None):
     tonemap = cv2.createTonemapMantiuk()
-    tonemap.setSaturation(1.2)
+    tonemap.setSaturation(1.6)
     tonemap.setScale(0.7)
     ldr = tonemap.process(hdr_image.copy())
     ldr_8bit = np.clip(ldr * 255, 0, 255).astype('uint8')
-    return ldr_8bit
+    return enhance_image(ldr_8bit, reference_image)
 
 def main():
     if len(sys.argv) < 3:
@@ -27,7 +53,8 @@ def main():
         sys.exit(1)
     images = load_images(aeb_images)
     hdr = create_hdr(images, exposure_times)
-    ldr = tonemap_mantiuk(hdr)
+    ref_image = get_medium_exposure_image(images, exposure_times)
+    ldr = tonemap_mantiuk(hdr, ref_image)
     cv2.imwrite(output_path, ldr)
     print(output_path)
 


### PR DESCRIPTION
## Summary
- enhance tonemapping by boosting saturation and contrast
- blend the tonemapped HDR result with the medium-exposure image for natural colors
- apply the new processing in CLI, GUI, and upload handler

## Testing
- `python -m py_compile find_and_merge_aeb.py hdr_gui.py process_uploads.py`


------
https://chatgpt.com/codex/tasks/task_e_686977947b4c832aabe92526061c7879