### PR TITLE
Add unit tests and utility module

### DIFF
--- a/find_and_merge_aeb.py
+++ b/find_and_merge_aeb.py
@@ -4,6 +4,7 @@ import sys
 import cv2
 import numpy as np
 from datetime import datetime, timedelta
+from hdr_utils import tonemap_mantiuk
 
 def find_aeb_images(directory):
     aeb_images = []
@@ -91,18 +92,11 @@ def create_hdr(images, exposure_times):
 
 
 def save_hdr_image(hdr_image, save_path, group_index):
-    # Use Mantiuk tonemapping
-    tonemapMantiuk = cv2.createTonemapMantiuk()
-    tonemapMantiuk.setSaturation(1.2)  # Adjust saturation (default 1.0)
-    tonemapMantiuk.setScale(0.7)  # Adjust scale factor for luminance (default 0.7)
-    ldrMantiuk = tonemapMantiuk.process(hdr_image.copy())
-    
-    # Clip the LDR image to the 0-255 range and convert to 8-bit
-    ldrMantiuk_8bit = np.clip(ldrMantiuk * 255, 0, 255).astype('uint8')
-
-    # Save the result
+    """Tonemap and save an HDR image."""
     output_path = os.path.join(save_path, f"hdr_image_{group_index}_mantiuk.jpg")
-    cv2.imwrite(output_path, ldrMantiuk_8bit)
+    ldr = tonemap_mantiuk(hdr_image)
+    cv2.imwrite(output_path, ldr)
+    return output_path
 
 
 if __name__ == "__main__":
@@ -121,7 +115,7 @@ if __name__ == "__main__":
         images = load_images(aeb_images)
         if images:
             hdr_image = create_hdr(images, exposure_times)
-            save_hdr_image(hdr_image, output_dir, group_index)
-            print(f"Group {group_index}: HDR image saved to {output_dir}/hdr_image_{group_index}.jpg")
+            output_path = save_hdr_image(hdr_image, output_dir, group_index)
+            print(f"Group {group_index}: HDR image saved to {output_path}")
         else:
             print(f"Group {group_index}: Failed to load images or exposure times are missing.")

--- a/hdr_gui.py
+++ b/hdr_gui.py
@@ -8,14 +8,7 @@ from find_and_merge_aeb import (
     load_images,
     create_hdr,
 )
-
-def tonemap_mantiuk(hdr_image):
-    tonemap = cv2.createTonemapMantiuk()
-    tonemap.setSaturation(1.2)
-    tonemap.setScale(0.7)
-    ldr = tonemap.process(hdr_image.copy())
-    ldr_8bit = np.clip(ldr * 255, 0, 255).astype('uint8')
-    return ldr_8bit
+from hdr_utils import tonemap_mantiuk
 
 class HDRGui:
     def __init__(self):

--- a/hdr_utils.py
+++ b/hdr_utils.py
@@ -1,0 +1,12 @@
+import cv2
+import numpy as np
+
+
+def tonemap_mantiuk(hdr_image, saturation=1.2, scale=0.7):
+    """Apply Mantiuk tonemapping and return an 8-bit image."""
+    tonemap = cv2.createTonemapMantiuk()
+    tonemap.setSaturation(saturation)
+    tonemap.setScale(scale)
+    ldr = tonemap.process(hdr_image.copy())
+    return np.clip(ldr * 255, 0, 255).astype("uint8")
+

--- a/process_uploads.py
+++ b/process_uploads.py
@@ -7,14 +7,7 @@ from find_and_merge_aeb import (
     load_images,
     create_hdr,
 )
-
-def tonemap_mantiuk(hdr_image):
-    tonemap = cv2.createTonemapMantiuk()
-    tonemap.setSaturation(1.2)
-    tonemap.setScale(0.7)
-    ldr = tonemap.process(hdr_image.copy())
-    ldr_8bit = np.clip(ldr * 255, 0, 255).astype('uint8')
-    return ldr_8bit
+from hdr_utils import tonemap_mantiuk
 
 def main():
     if len(sys.argv) < 3:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+import pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -1,0 +1,24 @@
+import subprocess
+from unittest import mock
+import find_and_merge_aeb as fa
+
+
+def fake_run(cmd, shell, stdout, text):
+    class R:
+        def __init__(self, out):
+            self.stdout = out
+    if "XPKeywords" in cmd:
+        img = cmd.split('"')[1]
+        return R("AEB" if img.endswith('1.jpg') else 'aeb')
+    if "ExposureTime" in cmd:
+        img = cmd.split('"')[1]
+        return R("1/2" if img.endswith('1.jpg') else "0.25")
+    return R("")
+
+
+@mock.patch.object(subprocess, "run", side_effect=fake_run)
+def test_find_aeb_images_and_exposure_times_from_list(mock_run):
+    images = ["1.jpg", "2.jpg"]
+    aeb, times = fa.find_aeb_images_and_exposure_times_from_list(images)
+    assert aeb == images
+    assert times == [0.5, 0.25]

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,0 +1,21 @@
+from datetime import datetime, timedelta
+from unittest import mock
+import find_and_merge_aeb as fa
+
+
+def test_group_images_by_datetime():
+    paths = ["img1.jpg", "img2.jpg", "img3.jpg", "img4.jpg"]
+    times = [
+        datetime(2024, 1, 1, 0, 0, 0),
+        datetime(2024, 1, 1, 0, 0, 1),
+        datetime(2024, 1, 1, 0, 0, 10),
+        datetime(2024, 1, 1, 0, 0, 11),
+    ]
+
+    def fake_extract(path):
+        return times[paths.index(path)]
+
+    with mock.patch.object(fa, "extract_datetime", side_effect=fake_extract):
+        groups = fa.group_images_by_datetime(paths, threshold=timedelta(seconds=2))
+
+    assert groups == [["img1.jpg", "img2.jpg"], ["img3.jpg", "img4.jpg"]]

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -1,0 +1,9 @@
+import os
+import numpy as np
+import find_and_merge_aeb as fa
+
+
+def test_save_hdr_image(tmp_path):
+    hdr = np.random.rand(2, 2, 3).astype(np.float32)
+    out = fa.save_hdr_image(hdr, tmp_path, 1)
+    assert os.path.exists(out)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,10 @@
+import numpy as np
+from hdr_utils import tonemap_mantiuk
+
+
+def test_tonemap_mantiuk_output_properties():
+    hdr = np.random.rand(2, 2, 3).astype(np.float32) * 2.0
+    ldr = tonemap_mantiuk(hdr)
+    assert ldr.shape == hdr.shape
+    assert ldr.dtype == np.uint8
+    assert ldr.min() >= 0 and ldr.max() <= 255


### PR DESCRIPTION
## Summary
- factor out common `tonemap_mantiuk` into `hdr_utils`
- refactor scripts to use the new utility
- return the saved path from `save_hdr_image`
- add unit tests for HDR utilities and grouping logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869785803ec832aa86d50b9f2371f00