### PR TITLE
Add anti-ghosting and auto alignment options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm run dev
 ```
 
 Open `http://localhost:3000` in your browser, select your AEB images and click **Create HDR**.
-The server-side script respects the `GHOST_LEVEL` and `AUTO_ALIGN` environment variables if you want to adjust these settings for uploads.
+The page includes a slider for ghost removal strength and a checkbox to enable automatic alignment. These values are sent to the backend, which sets the corresponding `GHOST_LEVEL` and `AUTO_ALIGN` environment variables when invoking `process_uploads.py`.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ This repository contains tools for merging Auto Exposure Bracketing (AEB) images
 
 ## Command Line Usage
 
-`find_and_merge_aeb.py` can be run directly to search a folder for AEB tagged images and create HDR files for each set found.
+`find_and_merge_aeb.py` can be run directly to search a folder for AEB tagged images and create HDR files for each set found. Optional flags enable automatic alignment and ghost removal.
 
 ```bash
-python find_and_merge_aeb.py <input_dir> <output_dir>
+python find_and_merge_aeb.py <input_dir> <output_dir> [--ghost LEVEL] [--align]
 ```
 
 ## GUI Application
 
-A simple DearPyGui based application is provided in `hdr_gui.py`. It allows you to select 3–5 images manually and create an HDR image which can be saved back to the same directory.
+A simple DearPyGui based application is provided in `hdr_gui.py`. It allows you to select 3–5 images manually and create an HDR image which can be saved back to the same directory. The interface includes a slider for ghost removal strength and a checkbox to automatically align the photos.
 
 Run the GUI with:
 
@@ -33,6 +33,7 @@ npm run dev
 ```
 
 Open `http://localhost:3000` in your browser, select your AEB images and click **Create HDR**.
+The server-side script respects the `GHOST_LEVEL` and `AUTO_ALIGN` environment variables if you want to adjust these settings for uploads.
 
 ### Docker
 

--- a/frontend/app/api/process/route.ts
+++ b/frontend/app/api/process/route.ts
@@ -10,6 +10,8 @@ const execFileAsync = promisify(execFile);
 export async function POST(req: Request) {
   const formData = await req.formData();
   const files = formData.getAll('images') as File[];
+  const ghost = (formData.get('ghost') || '0').toString();
+  const align = formData.get('align') === '1' ? '1' : '0';
   if (!files.length) {
     return new NextResponse('No files uploaded', { status: 400 });
   }
@@ -24,7 +26,9 @@ export async function POST(req: Request) {
   const outputPath = join(dir, 'result.jpg');
   try {
     const script = join(process.cwd(), '..', 'process_uploads.py');
-    await execFileAsync('python3', [script, ...paths, outputPath]);
+    await execFileAsync('python3', [script, ...paths, outputPath], {
+      env: { ...process.env, GHOST_LEVEL: ghost, AUTO_ALIGN: align },
+    });
     const data = await fs.readFile(outputPath);
     return new NextResponse(data, {
       status: 200,

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,6 +7,8 @@ export default function Home() {
   const [resultUrl, setResultUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [previews, setPreviews] = useState<string[]>([]);
+  const [ghostLevel, setGhostLevel] = useState(0);
+  const [autoAlign, setAutoAlign] = useState(false);
 
   const handleFilesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const f = e.target.files;
@@ -19,11 +21,21 @@ export default function Home() {
     }
   };
 
+  const handleGhostChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setGhostLevel(parseFloat(e.target.value));
+  };
+
+  const handleAlignChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setAutoAlign(e.target.checked);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!files || files.length === 0) return;
     const formData = new FormData();
     Array.from(files).forEach((f) => formData.append("images", f));
+    formData.append("ghost", ghostLevel.toString());
+    formData.append("align", autoAlign ? "1" : "0");
     setLoading(true);
     setResultUrl(null);
     const res = await fetch("/api/process", { method: "POST", body: formData });
@@ -57,6 +69,22 @@ export default function Home() {
           <Button variant="contained" component="span">
             Choose Images
           </Button>
+        </label>
+        <label className="flex items-center gap-2">
+          Ghost Removal
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.1"
+            value={ghostLevel}
+            onChange={handleGhostChange}
+          />
+          <span>{ghostLevel.toFixed(1)}</span>
+        </label>
+        <label className="flex items-center gap-2">
+          <input type="checkbox" checked={autoAlign} onChange={handleAlignChange} />
+          Auto Align
         </label>
         <Button type="submit" variant="contained">
           Create HDR

--- a/hdr_gui.py
+++ b/hdr_gui.py
@@ -52,6 +52,8 @@ class HDRGui:
         with dpg.window(label="HDR Compositor", width=800, height=600):
             dpg.add_button(label="Select Images", callback=self.select_files)
             self.listbox = dpg.add_listbox(items=[], num_items=5, width=780)
+            self.ghost_slider = dpg.add_slider_float(label="Ghost Removal", min_value=0.0, max_value=1.0, default_value=0.0, width=200)
+            self.align_checkbox = dpg.add_checkbox(label="Auto Align")
             dpg.add_button(label="Create HDR", callback=self.create_hdr_image)
             self.save_btn = dpg.add_button(label="Save Result", callback=self.save_image, enabled=False)
             with dpg.group() as self.image_group:
@@ -78,7 +80,9 @@ class HDRGui:
             dpg.log_warning("Selected images do not contain enough AEB exposures.")
             return
         images = load_images(aeb_images)
-        self.hdr_image = create_hdr(images, exposure_times)
+        ghost_level = dpg.get_value(self.ghost_slider)
+        auto_align = dpg.get_value(self.align_checkbox)
+        self.hdr_image = create_hdr(images, exposure_times, ghost_level, auto_align)
         ref_image = get_medium_exposure_image(images, exposure_times)
         self.ldr_image = tonemap_mantiuk(self.hdr_image, ref_image)
         self.display_image(self.ldr_image)

--- a/process_uploads.py
+++ b/process_uploads.py
@@ -44,7 +44,10 @@ def tonemap_mantiuk(hdr_image, reference_image=None):
 
 def main():
     if len(sys.argv) < 3:
-        print("Usage: process_uploads.py <image1> [<image2> ...] <output>")
+        print(
+            "Usage: process_uploads.py <image1> [<image2> ...] <output>"
+            "\nOptional environment variables: GHOST_LEVEL (0-1), AUTO_ALIGN=1"
+        )
         sys.exit(1)
     *image_paths, output_path = sys.argv[1:]
     aeb_images, exposure_times = find_aeb_images_and_exposure_times_from_list(image_paths)
@@ -52,7 +55,9 @@ def main():
         print("No AEB-tagged images found", file=sys.stderr)
         sys.exit(1)
     images = load_images(aeb_images)
-    hdr = create_hdr(images, exposure_times)
+    ghost_level = float(os.environ.get("GHOST_LEVEL", "0"))
+    auto_align = os.environ.get("AUTO_ALIGN", "0") == "1"
+    hdr = create_hdr(images, exposure_times, ghost_level, auto_align)
     ref_image = get_medium_exposure_image(images, exposure_times)
     ldr = tonemap_mantiuk(hdr, ref_image)
     cv2.imwrite(output_path, ldr)


### PR DESCRIPTION
## Summary
- add `align_images` and `apply_anti_ghosting` helpers
- allow passing ghost removal level and alignment to `create_hdr`
- expose new options in the CLI, GUI and upload script
- document these features in README

## Testing
- `python -m py_compile find_and_merge_aeb.py hdr_gui.py process_uploads.py`
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68697a33c860832aa17218b1a58de3d4