### PR TITLE
Fix Makefile run rule

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --no-cache-dir opencv-python-headless numpy
 
 # copy python scripts
-COPY find_and_merge_aeb.py process_uploads.py ./
+COPY find_and_merge_aeb.py process_uploads.py hdr_utils.py ./
 
 # copy frontend
 COPY frontend/package.json frontend/package-lock.json ./frontend/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: run
 
 run:
-        docker buildx build --load -f Dockerfile.web -t hdr-webapp .
+	docker buildx build --load -f Dockerfile.web -t hdr-webapp .
 	# run container and stop it cleanly on Ctrl+C
 	docker run --rm -p 3000:3000 --name hdr-webapp-container hdr-webapp & \
 	pid=$$!; trap "docker stop hdr-webapp-container >/dev/null" INT TERM; \


### PR DESCRIPTION
## Summary
- correct indentation in `Makefile` `run` target to use a TAB
- copy `hdr_utils.py` in the web Dockerfile so imports work in the container

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `make run` *(fails: docker missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_686996b1e004832abb1a438f1c850f09