### PR TITLE
Fix Docker build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: run
 
 run:
-        # Use BuildKit directly so buildx is not required
-        DOCKER_BUILDKIT=1 docker build -f Dockerfile.web -t hdr-webapp .
+	# Use BuildKit directly so buildx is not required
+	DOCKER_BUILDKIT=1 docker build -f Dockerfile.web -t hdr-webapp .
 	# run container and stop it cleanly on Ctrl+C
 	docker run --rm -p 3000:3000 --name hdr-webapp-container hdr-webapp & \
 	pid=$$!; trap "docker stop hdr-webapp-container >/dev/null" INT TERM; \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: run
 
 run:
-	# Use BuildKit directly so buildx is not required
-	DOCKER_BUILDKIT=1 docker build -f Dockerfile.web -t hdr-webapp .
+	# Build the webapp container image without requiring Buildx
+	docker build -f Dockerfile.web -t hdr-webapp .
 	# run container and stop it cleanly on Ctrl+C
 	docker run --rm -p 3000:3000 --name hdr-webapp-container hdr-webapp & \
 	pid=$$!; trap "docker stop hdr-webapp-container >/dev/null" INT TERM; \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: run
 
 run:
-	docker buildx build --load -f Dockerfile.web -t hdr-webapp .
+        # Use BuildKit directly so buildx is not required
+        DOCKER_BUILDKIT=1 docker build -f Dockerfile.web -t hdr-webapp .
 	# run container and stop it cleanly on Ctrl+C
 	docker run --rm -p 3000:3000 --name hdr-webapp-container hdr-webapp & \
 	pid=$$!; trap "docker stop hdr-webapp-container >/dev/null" INT TERM; \

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,11 @@
 .PHONY: run
 
 run:
-	# Build the webapp container image without requiring Buildx
-	docker build -f Dockerfile.web -t hdr-webapp .
-	# run container and stop it cleanly on Ctrl+C
-	docker run --rm -p 3000:3000 --name hdr-webapp-container hdr-webapp & \
-	pid=$$!; trap "docker stop hdr-webapp-container >/dev/null" INT TERM; \
-	wait $$pid
+       docker buildx build --load -f Dockerfile.web -t hdr-webapp .
+       # run container and stop it cleanly on Ctrl+C
+       docker run --rm -p 3000:3000 --name hdr-webapp-container hdr-webapp & \
+       pid=$$!; trap "docker stop hdr-webapp-container >/dev/null" INT TERM; \
+       wait $$pid
 
 # Run the HDR GUI application
 #run:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To run the web interface in a container, simply execute:
 make run
 ```
 
-This builds an image using `Dockerfile.web` without requiring the Docker Buildx plugin and starts the app on port 3000.
+This builds an image using `Dockerfile.web` with Docker Buildx and starts the app on port 3000. Make sure the Buildx component is installed as described in the Docker documentation.
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To run the web interface in a container, simply execute:
 make run
 ```
 
-This builds an image using `Dockerfile.web` with Docker Buildx and starts the app on port 3000. Make sure the Buildx component is installed as described in the Docker documentation.
+This builds an image using `Dockerfile.web` with Docker BuildKit enabled and starts the app on port 3000. No additional Buildx plugin is required.
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To run the web interface in a container, simply execute:
 make run
 ```
 
-This builds an image using `Dockerfile.web` with Docker BuildKit enabled and starts the app on port 3000. No additional Buildx plugin is required.
+This builds an image using `Dockerfile.web` without requiring the Docker Buildx plugin and starts the app on port 3000.
 
 ### Requirements
 


### PR DESCRIPTION
## Summary
- update Makefile to build without needing buildx
- clarify README Docker instructions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68699934c02c832a8a53be577057c301