### PR TITLE
Add adjustable image settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ python hdr_gui.py
 ```
 
 After selecting images, click **Create HDR** and then **Save Result** to write `hdr_result.jpg` next to the chosen files.
+Use the sliders to tweak saturation, contrast, gamma and brightness before saving.
 
 ## Web Interface
 

--- a/process_uploads.py
+++ b/process_uploads.py
@@ -25,6 +25,8 @@ def main():
     parser.add_argument("--deghost", action="store_true", help="apply anti-ghosting")
     parser.add_argument("--contrast", type=float, default=1.0, help="tone mapping contrast scale")
     parser.add_argument("--saturation", type=float, default=1.0, help="tone mapping saturation")
+    parser.add_argument("--gamma", type=float, default=1.0, help="tone mapping gamma")
+    parser.add_argument("--brightness", type=float, default=1.0, help="output brightness scale")
     args = parser.parse_args()
 
     if len(args.paths) < 2:
@@ -44,6 +46,8 @@ def main():
         ref_image,
         saturation=args.saturation,
         contrast=args.contrast,
+        gamma=args.gamma,
+        brightness=args.brightness,
     )
     cv2.imwrite(output_path, ldr)
     print(output_path)

--- a/tests/test_hdr_utils.py
+++ b/tests/test_hdr_utils.py
@@ -63,3 +63,13 @@ def test_tonemap_preserves_highlights():
     ldr = tonemap_mantiuk(hdr)
     # Top-left pixel corresponds to the bright spot in all exposures
     assert ldr[0, 0].mean() > 200
+
+
+def test_tonemap_gamma_brightness():
+    base = np.arange(16 * 3, dtype=np.uint8).reshape(4, 4, 3)
+    images = [base, base + 20, base + 40]
+    times = [1 / 30, 1 / 60, 1 / 125]
+    hdr = create_hdr(images, times)
+    normal = tonemap_mantiuk(hdr)
+    adjusted = tonemap_mantiuk(hdr, gamma=0.5, brightness=1.5)
+    assert adjusted.mean() >= normal.mean()


### PR DESCRIPTION
## Summary
- update tone mapping to allow gamma and brightness control
- add sliders in `hdr_gui` for saturation, contrast, gamma, and brightness
- expose gamma and brightness options in `process_uploads.py`
- document new GUI sliders
- test extra parameters

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6dd7b7b4832aaa04325311370f68