### PR TITLE
Add CI workflow and more tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest -q
+

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+import subprocess
+import datetime
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT.parent))
+
+from HDR_Compositor.find_and_merge_aeb import (
+    group_images_by_datetime,
+    find_aeb_images_and_exposure_times_from_list,
+)
+from HDR_Compositor.hdr_utils import align_images, remove_ghosts
+
+
+def test_align_remove_empty():
+    assert align_images([]) == []
+    assert remove_ghosts([]) == []
+
+
+def test_group_images_missing_datetime(monkeypatch):
+    monkeypatch.setattr(
+        'HDR_Compositor.find_and_merge_aeb.extract_datetime',
+        lambda p: None,
+    )
+    groups = group_images_by_datetime(['a.jpg', 'b.jpg'])
+    assert groups == []
+
+
+def test_find_aeb_images_and_exposure_times(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, shell, stdout, text):
+        calls.append(cmd)
+        class R:
+            def __init__(self, out):
+                self.stdout = out
+        if 'XPKeywords' in cmd:
+            if 'img1.jpg' in cmd:
+                return R('AEB')
+            return R('')
+        if 'ExposureTime' in cmd:
+            return R('1/60')
+        return R('')
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    images, times = find_aeb_images_and_exposure_times_from_list(['img1.jpg', 'img2.jpg'])
+    assert images == ['img1.jpg']
+    assert times == [1/60]
+    # Ensure subprocess.run was called for each image
+    assert any('XPKeywords "img1.jpg"' in c for c in calls)
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests on pushes and PRs
- extend test suite with additional edge case tests for image grouping and subprocess calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6fe6bc28832a99391de124779c3d