### PR TITLE
Add Makefile target for GUI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
-.PHONY: run
+.PHONY: run gui
 
 run:
-	docker build -f Dockerfile.web -t hdr-webapp .
-	# run container and stop it cleanly on Ctrl+C
-	docker run --rm -p 3000:3000 --name hdr-webapp-container hdr-webapp & \
-	pid=$$!; trap "docker stop hdr-webapp-container >/dev/null" INT TERM; \
-	wait $$pid
+        docker build -f Dockerfile.web -t hdr-webapp .
+        # run container and stop it cleanly on Ctrl+C
+        docker run --rm -p 3000:3000 --name hdr-webapp-container hdr-webapp & \
+        pid=$$!; trap "docker stop hdr-webapp-container >/dev/null" INT TERM; \
+        wait $$pid
 
-# Run the HDR GUI application
-#run:
-#	python hdr_gui.py
+# Launch the desktop HDR compositor GUI
+gui:
+	python hdr_gui.py
+
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Run the GUI with:
 python hdr_gui.py
 ```
 
+You can also start it using the provided Makefile:
+
+```bash
+make gui
+```
+
 After selecting images, click **Create HDR** and then **Save Result** to write `hdr_result.jpg` next to the chosen files.
 Use the sliders to tweak saturation, contrast, gamma and brightness before saving.
 


### PR DESCRIPTION
## Summary
- add a `gui` target to the Makefile for launching `hdr_gui.py`
- document `make gui` usage in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a73c82288832aae6a161a1a3dec2b