### PR TITLE
Fix Makefile indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 .PHONY: run gui
 
 run:
-        docker build -f Dockerfile.web -t hdr-webapp .
-        # run container and stop it cleanly on Ctrl+C
-        docker run --rm -p 3000:3000 --name hdr-webapp-container hdr-webapp & \
-        pid=$$!; trap "docker stop hdr-webapp-container >/dev/null" INT TERM; \
-        wait $$pid
+	docker build -f Dockerfile.web -t hdr-webapp .
+	# run container and stop it cleanly on Ctrl+C
+	docker run --rm -p 3000:3000 --name hdr-webapp-container hdr-webapp & \
+	pid=$$!; trap "docker stop hdr-webapp-container >/dev/null" INT TERM; \
+	wait $$pid
 
 # Launch the desktop HDR compositor GUI
 gui:


### PR DESCRIPTION
## Summary
- fix indentation for all Makefile commands so that `make run` succeeds

## Testing
- `pytest -q`
- `make run` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a7615a2cc832ab99c183e2c929055