### PR TITLE
Add theme colors and depth

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3,6 +3,8 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --primary: #3b82f6;
+  --secondary: #f97316;
 }
 
 @theme inline {
@@ -16,11 +18,13 @@
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    --primary: #60a5fa;
+    --secondary: #fb923c;
   }
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans, Arial, Helvetica, sans-serif);
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,19 @@
+"use client";
 import type { Metadata } from "next";
 import "./globals.css";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import CssBaseline from "@mui/material/CssBaseline";
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: "#3b82f6",
+    },
+    secondary: {
+      main: "#f97316",
+    },
+  },
+});
 
 export const metadata: Metadata = {
   title: "AEB Compositor",
@@ -9,7 +23,12 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="antialiased">{children}</body>
+      <body className="antialiased">
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          {children}
+        </ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -304,11 +304,11 @@ export default function Home() {
   return (
     <main className="flex flex-col items-center p-4 gap-4">
       <Paper
-        variant="outlined"
+        elevation={3}
         className={`p-8 text-center w-full max-w-xl cursor-pointer ${
           dragging ? "bg-gray-100" : ""
         }`}
-        sx={{ borderStyle: "dashed", borderWidth: 2 }}
+        sx={{ borderStyle: "dashed", borderWidth: 2, borderColor: "primary.main" }}
         onDragOver={(e) => {
           e.preventDefault();
           e.stopPropagation();
@@ -340,7 +340,7 @@ export default function Home() {
       )}
 
       {queue.length > 0 && (
-        <Paper className="w-full max-w-xl p-2" elevation={2}>
+        <Paper className="w-full max-w-xl p-2" elevation={3}>
           <Typography variant="subtitle2" sx={{ mb: 1 }}>
             Processing Queue
           </Typography>
@@ -391,21 +391,21 @@ export default function Home() {
               )}
             </div>
             {groups[0].resultUrl && (
-              <Paper className="flex flex-col items-center gap-2 p-2" elevation={2}>
+              <Paper className="flex flex-col items-center gap-2 p-2" elevation={3}>
                 <Typography variant="subtitle2">HDR Result</Typography>
                 <img
                   src={groups[0].resultUrl}
                   className="w-48 h-48 object-cover rounded-lg"
                 />
                 <a href={groups[0].resultUrl} download="hdr_result.jpg">
-                  <Button variant="outlined" size="small">Download</Button>
+                  <Button variant="outlined" color="secondary" size="small">Download</Button>
                 </a>
               </Paper>
             )}
           </div>
           {groups[0].resultUrl && (
             <div className="flex justify-end mt-2">
-              <Button variant="outlined" onClick={handleDownloadAll}>
+              <Button variant="outlined" color="secondary" onClick={handleDownloadAll}>
                 Download All
               </Button>
             </div>
@@ -448,14 +448,14 @@ export default function Home() {
                   )}
                 </div>
                 {g.resultUrl && (
-                  <Paper className="flex flex-col items-center gap-2 p-2" elevation={2}>
+                  <Paper className="flex flex-col items-center gap-2 p-2" elevation={3}>
                     <Typography variant="subtitle2">HDR Result</Typography>
                     <img
                       src={g.resultUrl}
                       className="w-48 h-48 object-cover rounded-lg"
                     />
                     <a href={g.resultUrl} download={`hdr_group_${idx + 1}.jpg`}>
-                      <Button size="small" variant="outlined">Download</Button>
+                      <Button size="small" variant="outlined" color="secondary">Download</Button>
                     </a>
                   </Paper>
                 )}
@@ -467,7 +467,7 @@ export default function Home() {
               Create All
             </Button>
             {groups.some((g) => g.resultUrl) && (
-              <Button variant="outlined" onClick={handleDownloadAll}>
+              <Button variant="outlined" color="secondary" onClick={handleDownloadAll}>
                 Download All
               </Button>
             )}


### PR DESCRIPTION
## Summary
- define primary and secondary CSS variables
- wrap app with Material UI ThemeProvider
- elevate papers and add secondary color on download buttons

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686abfd40ea4832abc64865fbf7e1c43