### PR TITLE
Fix build and compile errors

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,19 +1,6 @@
-"use client";
 import type { Metadata } from "next";
 import "./globals.css";
-import { ThemeProvider, createTheme } from "@mui/material/styles";
-import CssBaseline from "@mui/material/CssBaseline";
-
-const theme = createTheme({
-  palette: {
-    primary: {
-      main: "#3b82f6",
-    },
-    secondary: {
-      main: "#f97316",
-    },
-  },
-});
+import ClientThemeProvider from "../components/ClientThemeProvider";
 
 export const metadata: Metadata = {
   title: "AEB Compositor",
@@ -24,10 +11,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className="antialiased">
-        <ThemeProvider theme={theme}>
-          <CssBaseline />
-          {children}
-        </ThemeProvider>
+        <ClientThemeProvider>{children}</ClientThemeProvider>
       </body>
     </html>
   );

--- a/frontend/components/ClientThemeProvider.tsx
+++ b/frontend/components/ClientThemeProvider.tsx
@@ -1,0 +1,20 @@
+"use client";
+import React from "react";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import CssBaseline from "@mui/material/CssBaseline";
+
+const theme = createTheme({
+  palette: {
+    primary: { main: "#3b82f6" },
+    secondary: { main: "#f97316" },
+  },
+});
+
+export default function ClientThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </ThemeProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- ensure dependencies installed for tests
- create a client-only theme provider component
- use the new theme provider in `layout.tsx` to avoid Next.js build errors

## Testing
- `pytest -q`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c0e4f2dc8832a933aeb2811303691