### PR TITLE
Add frontend build test and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest
+          cd frontend && npm ci && cd ..
       - name: Run tests
-        run: pytest -q
+        run: |
+          npm --prefix frontend run build
+          pytest -q
 

--- a/tests/test_frontend_build.py
+++ b/tests/test_frontend_build.py
@@ -1,0 +1,15 @@
+import pytest
+import subprocess
+from pathlib import Path
+import shutil
+
+
+def test_frontend_build():
+    frontend = Path(__file__).resolve().parents[1] / "frontend"
+    npm = shutil.which("npm")
+    if npm is None:
+        pytest.skip("npm not installed")
+    subprocess.run([npm, "ci", "--no-audit", "--no-fund"], cwd=frontend, check=True)
+    subprocess.run([npm, "run", "build"], cwd=frontend, check=True)
+
+


### PR DESCRIPTION
## Summary
- add a new test that verifies the frontend can build
- update CI workflow to install Node, install frontend deps and run the build before running tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c105dbc34832aa58b3d80c19f04b6