### PR TITLE
Add header and description to HDR web interface

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -303,6 +303,11 @@ export default function Home() {
 
   return (
     <main className="flex flex-col items-center p-4 gap-4">
+      <h1 className="text-3xl font-bold">HDR Compositor</h1>
+      <p className="text-center max-w-xl">
+        Select your bracketed images to merge them into a single high dynamic
+        range photo.
+      </p>
       <Paper
         elevation={3}
         className={`p-8 text-center w-full max-w-xl cursor-pointer ${


### PR DESCRIPTION
## Summary
- show a title and explanatory text in the Next.js app

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c0fd37bac832aab6ac0e679af9cc8