### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,30 @@
+name: Build and Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+          cd frontend && npm ci && cd ..
+      - name: Build frontend
+        run: npm --prefix frontend run build
+      - name: Run tests
+        run: pytest -q


### PR DESCRIPTION
## Summary
- add `Build and Test` workflow to install dependencies, build the frontend, and run `pytest`

## Testing
- `pytest -q`
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_686c296dbfec832a8c118def99850fa3