### PR TITLE
Add multiple HDR tone mapping options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ make gui
 
 After selecting images, click **Create HDR** and then **Save Result** to write `hdr_result.jpg` next to the chosen files.
 Use the sliders to tweak saturation, contrast, gamma and brightness before saving.
+You can choose between *Mantiuk*, *Reinhard* and *Drago* tone mapping via the new radio buttons.
 
 ## Web Interface
 

--- a/hdr_gui.py
+++ b/hdr_gui.py
@@ -9,14 +9,14 @@ try:  # support running as part of a package or as a script
         load_images,
         create_hdr,
     )
-    from .hdr_utils import get_medium_exposure_image, tonemap_mantiuk
+    from .hdr_utils import get_medium_exposure_image, tonemap
 except ImportError:  # pragma: no cover - fallback for direct execution
     from find_and_merge_aeb import (
         find_aeb_images_and_exposure_times_from_list,
         load_images,
         create_hdr,
     )
-    from hdr_utils import get_medium_exposure_image, tonemap_mantiuk
+    from hdr_utils import get_medium_exposure_image, tonemap
 
 class HDRGui:
     def __init__(self):
@@ -38,6 +38,13 @@ class HDRGui:
                     self.save_btn = dpg.add_button(label="Save Result", callback=self.save_image, enabled=False)
                     dpg.add_separator()
                     dpg.add_text("Adjustments")
+                    dpg.add_radio_button(
+                        ("Mantiuk", "Reinhard", "Drago"),
+                        tag="tonemap_algo",
+                        default_value="Mantiuk",
+                        callback=self.update_preview,
+                        horizontal=True,
+                    )
                     dpg.add_slider_float(label="Saturation", tag="sat_slider", default_value=1.0, min_value=0.0, max_value=2.0, callback=self.update_preview)
                     dpg.add_slider_float(label="Contrast", tag="contrast_slider", default_value=1.0, min_value=0.0, max_value=2.0, callback=self.update_preview)
                     dpg.add_slider_float(label="Gamma", tag="gamma_slider", default_value=1.0, min_value=0.1, max_value=2.5, callback=self.update_preview)
@@ -88,9 +95,11 @@ class HDRGui:
         con = dpg.get_value("contrast_slider")
         gamma = dpg.get_value("gamma_slider")
         bright = dpg.get_value("brightness_slider")
-        self.ldr_image = tonemap_mantiuk(
+        algo = dpg.get_value("tonemap_algo").lower()
+        self.ldr_image = tonemap(
             self.hdr_image,
             self.ref_image,
+            algorithm=algo,
             saturation=sat,
             contrast=con,
             gamma=gamma,

--- a/process_uploads.py
+++ b/process_uploads.py
@@ -9,14 +9,14 @@ try:  # allow usage both as script and module
         load_images,
         create_hdr,
     )
-    from .hdr_utils import get_medium_exposure_image, tonemap_mantiuk
+    from .hdr_utils import get_medium_exposure_image, tonemap
 except ImportError:  # pragma: no cover - fallback for direct execution
     from find_and_merge_aeb import (
         find_aeb_images_and_exposure_times_from_list,
         load_images,
         create_hdr,
     )
-    from hdr_utils import get_medium_exposure_image, tonemap_mantiuk
+    from hdr_utils import get_medium_exposure_image, tonemap
 
 def main():
     parser = argparse.ArgumentParser(description="Process uploaded images")
@@ -27,6 +27,12 @@ def main():
     parser.add_argument("--saturation", type=float, default=1.0, help="tone mapping saturation")
     parser.add_argument("--gamma", type=float, default=1.0, help="tone mapping gamma")
     parser.add_argument("--brightness", type=float, default=1.0, help="output brightness scale")
+    parser.add_argument(
+        "--algorithm",
+        choices=["mantiuk", "reinhard", "drago"],
+        default="mantiuk",
+        help="tone mapping algorithm",
+    )
     args = parser.parse_args()
 
     if len(args.paths) < 2:
@@ -48,9 +54,10 @@ def main():
     hdr = create_hdr(images, exposure_times, align=args.align, deghost=args.deghost)
     progress(70)
     ref_image = get_medium_exposure_image(images, exposure_times)
-    ldr = tonemap_mantiuk(
+    ldr = tonemap(
         hdr,
         ref_image,
+        algorithm=args.algorithm,
         saturation=args.saturation,
         contrast=args.contrast,
         gamma=args.gamma,

--- a/tests/test_hdr_utils.py
+++ b/tests/test_hdr_utils.py
@@ -10,6 +10,7 @@ from HDR_Compositor.hdr_utils import (
     get_medium_exposure_image,
     enhance_image,
     tonemap_mantiuk,
+    tonemap,
     align_images,
     remove_ghosts,
 )
@@ -73,3 +74,14 @@ def test_tonemap_gamma_brightness():
     normal = tonemap_mantiuk(hdr)
     adjusted = tonemap_mantiuk(hdr, gamma=0.5, brightness=1.5)
     assert adjusted.mean() >= normal.mean()
+
+
+def test_other_tone_mapping_algorithms():
+    base = np.arange(16 * 3, dtype=np.uint8).reshape(4, 4, 3)
+    images = [base, base + 20, base + 40]
+    times = [1 / 30, 1 / 60, 1 / 125]
+    hdr = create_hdr(images, times)
+    for algo in ("reinhard", "drago"):
+        ldr = tonemap(hdr, algorithm=algo)
+        assert ldr.dtype == np.uint8
+        assert ldr.shape == images[0].shape


### PR DESCRIPTION
## Summary
- introduce a generic `tonemap` function supporting Mantiuk, Reinhard and Drago algorithms
- keep `tonemap_mantiuk` for backwards compatibility
- expose algorithm selection via CLI and GUI radio buttons
- update tests for the new API
- mention tone mapping choices in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c43b5ace4832abca703acf0a3e1de