### PR TITLE
Add alignment/deghost preview to HDR GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ make gui
 
 After selecting images, click **Create HDR** and then **Save Result** to write `hdr_result.jpg` next to the chosen files.
 Use the sliders to tweak saturation, contrast, gamma and brightness before saving.
+Two extra buttons let you preview how **Auto Align** and **Deghost** will affect the result before creating the final HDR.
 
 ## Web Interface
 


### PR DESCRIPTION
## Summary
- import `align_images` and `remove_ghosts` in the GUI
- add `Preview Alignment` and `Preview Deghost` buttons
- implement preview methods to show aligned or deghosted results
- document the new preview buttons in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c40bfd4a0832aabbbc2761c5f318d