### PR TITLE
Add make targets for native install and run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,19 @@
-.PHONY: run gui
+.PHONY: run gui install docker-run
 
 run:
-	docker build -f Dockerfile.web -t hdr-webapp .
-	# run container and stop it cleanly on Ctrl+C
-	docker run --rm -p 3000:3000 --name hdr-webapp-container hdr-webapp & \
-	pid=$$!; trap "docker stop hdr-webapp-container >/dev/null" INT TERM; \
-	wait $$pid
+        cd frontend && npm run dev
+
+install:
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        cd frontend && npm install
+
+docker-run:
+        docker build -f Dockerfile.web -t hdr-webapp .
+        # run container and stop it cleanly on Ctrl+C
+        docker run --rm -p 3000:3000 --name hdr-webapp-container hdr-webapp & \
+        pid=$$!; trap "docker stop hdr-webapp-container >/dev/null" INT TERM; \
+        wait $$pid
 
 # Launch the desktop HDR compositor GUI
 gui:


### PR DESCRIPTION
## Summary
- add `install` target to install Python and Node dependencies
- run frontend natively via `make run`
- keep container support with a new `docker-run` target

## Testing
- `python -m pip install -r requirements.txt`
- `cd frontend && npm install`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c55d9648c832ab18f4cfa21ae4521