### PR TITLE
Add favicon support to Next.js frontend

### DIFF
--- a/frontend/app/icon.svg
+++ b/frontend/app/icon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="HDR Merge">
+  <defs>
+    <!-- Gradient to suggest HDR brightness range -->
+    <linearGradient id="hdrGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#bbb"></stop>
+      <stop offset="50%" stop-color="#fff"></stop>
+      <stop offset="100%" stop-color="#888"></stop>
+    </linearGradient>
+  </defs>
+
+  <!-- Label -->
+  <text x="32" y="14" text-anchor="middle" font-family="sans-serif" font-size="10" font-weight="bold" fill="#333">
+    HDR
+  </text>
+
+  <!-- Three stacked “photo” frames -->
+  <rect x="4" y="24" width="40" height="28" rx="2" ry="2" fill="#666" stroke="#333" stroke-width="2"></rect>
+  <rect x="12" y="16" width="40" height="28" rx="2" ry="2" fill="#888" stroke="#333" stroke-width="2"></rect>
+  <rect x="20" y="24" width="40" height="28" rx="2" ry="2" fill="url(#hdrGrad)" stroke="#333" stroke-width="2"></rect>
+</svg>


### PR DESCRIPTION
## Summary
- copy existing favicon.svg into `app/icon.svg` so Next.js sets the site icon automatically

## Testing
- `npm run build` inside frontend
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c5a11c938832a8bb56df8e122c783