### PR TITLE
Fix HDR creation when metadata warnings occur

### DIFF
--- a/find_and_merge_aeb.py
+++ b/find_and_merge_aeb.py
@@ -95,7 +95,8 @@ def find_aeb_images_and_exposure_times_from_list(image_paths):
                 except ValueError:
                     # Handle images without a valid exposure time or where parsing fails
                     print(
-                        f"Warning: Could not parse exposure time for image {os.path.basename(image_path)} with value '{exposure_time_str}'. Skipping this image."
+                        f"Warning: Could not parse exposure time for image {os.path.basename(image_path)} with value '{exposure_time_str}'. Skipping this image.",
+                        file=sys.stderr,
                     )
                     aeb_images.pop()  # Remove the last image added since it has no valid exposure time
                     continue  # Skip further processing for this image


### PR DESCRIPTION
## Summary
- ensure `find_aeb_images_and_exposure_times_from_list` prints parsing warnings to stderr

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c5a672a64832a99fd4d1b1c788cf2