### PR TITLE
Improve error handling when HDR result is missing

### DIFF
--- a/frontend/app/api/process/route.ts
+++ b/frontend/app/api/process/route.ts
@@ -69,8 +69,18 @@ export async function POST(req: Request) {
       send('error', d.toString());
     });
 
-    child.on('close', async (code) => {
-      console.log('Process exited with code', code);
+    child.on('error', (err) => {
+      console.error('Failed to start process:', err);
+      send('error', `spawn error: ${err.message}`);
+    });
+
+    child.on('close', async (code, signal) => {
+      console.log('Process exited with code', code, 'signal', signal);
+      if (signal) {
+        send('error', `Process terminated by signal ${signal}`);
+        writer.close();
+        return;
+      }
       const target = finalPath || outputPath;
       try {
         await fs.access(target);

--- a/frontend/app/api/process/route.ts
+++ b/frontend/app/api/process/route.ts
@@ -61,9 +61,13 @@ export async function POST(req: Request) {
     });
 
     child.on('close', async () => {
+      const target = finalPath || outputPath;
       try {
-        const data = await fs.readFile(finalPath || outputPath);
+        await fs.access(target);
+        const data = await fs.readFile(target);
         send('done', data.toString('base64'));
+      } catch {
+        send('error', `File not found: ${target}`);
       } finally {
         writer.close();
       }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -159,7 +159,9 @@ export default function Home() {
       formData.append("saturation", (2 - saturation).toString());
       setLoading(true);
       try {
+        console.log('Sending HDR request for group', index);
         const res = await fetch("/api/process", { method: "POST", body: formData });
+        console.log('Response status', res.status);
         if (!res.ok || !res.body) throw new Error("request failed");
         const reader = res.body.getReader();
         const decoder = new TextDecoder();
@@ -185,6 +187,7 @@ export default function Home() {
               currentEvent = valueStr;
             } else if (field === "data") {
               if (currentEvent === "progress") {
+                console.log('Progress', valueStr);
                 const pct = parseInt(valueStr, 10);
                 setGroups((gs) => {
                   const copy = [...gs];
@@ -199,6 +202,7 @@ export default function Home() {
                 }
                 const blob = new Blob([bytes], { type: "image/jpeg" });
                 resultUrl = URL.createObjectURL(blob);
+                console.log('HDR result ready');
               }
             }
           }
@@ -213,6 +217,7 @@ export default function Home() {
             return copy;
           });
         } else {
+          console.warn('No result received for group', index);
           setGroups((gs) => {
             const copy = [...gs];
             copy[index].status = "error";
@@ -220,6 +225,7 @@ export default function Home() {
           });
         }
       } catch (e) {
+        console.error('HDR request failed', e);
         setGroups((gs) => {
           const copy = [...gs];
           copy[index].status = "error";

--- a/process_uploads.py
+++ b/process_uploads.py
@@ -40,33 +40,41 @@ def main():
         sys.exit(1)
 
     *image_paths, output_path = args.paths
-    aeb_images, exposure_times = find_aeb_images_and_exposure_times_from_list(image_paths)
-    if not aeb_images:
-        print("No AEB-tagged images found", file=sys.stderr)
-        sys.exit(1)
+    try:
+        aeb_images, exposure_times = find_aeb_images_and_exposure_times_from_list(image_paths)
+        if not aeb_images:
+            print("No AEB-tagged images found", file=sys.stderr)
+            return 1
 
-    def progress(pct: int):
-        print(f"PROGRESS {pct}", flush=True)
+        def progress(pct: int):
+            print(f"PROGRESS {pct}", flush=True)
 
-    progress(10)
-    images = load_images(aeb_images)
-    progress(40)
-    hdr = create_hdr(images, exposure_times, align=args.align, deghost=args.deghost)
-    progress(70)
-    ref_image = get_medium_exposure_image(images, exposure_times)
-    ldr = tonemap(
-        hdr,
-        ref_image,
-        algorithm=args.algorithm,
-        saturation=args.saturation,
-        contrast=args.contrast,
-        gamma=args.gamma,
-        brightness=args.brightness,
-    )
-    progress(90)
-    cv2.imwrite(output_path, ldr)
-    progress(100)
-    print(output_path)
+        progress(10)
+        images = load_images(aeb_images)
+        progress(40)
+        hdr = create_hdr(images, exposure_times, align=args.align, deghost=args.deghost)
+        progress(70)
+        ref_image = get_medium_exposure_image(images, exposure_times)
+        ldr = tonemap(
+            hdr,
+            ref_image,
+            algorithm=args.algorithm,
+            saturation=args.saturation,
+            contrast=args.contrast,
+            gamma=args.gamma,
+            brightness=args.brightness,
+        )
+        progress(90)
+        cv2.imwrite(output_path, ldr)
+        progress(100)
+        print(output_path)
+        return 0
+    except Exception as e:  # pragma: no cover - handle unexpected errors
+        import traceback
+
+        print("Unhandled exception:", file=sys.stderr)
+        traceback.print_exc()
+        return 1
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- avoid unhandled rejection in `/api/process` when the Python script fails
- check for the HDR result image before reading it

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c5fd7dab8832abc44127a2c92df30