### PR TITLE
Update favicon

### DIFF
--- a/frontend/app/icon.svg
+++ b/frontend/app/icon.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <!-- Arrowhead marker -->
+    <marker id="arrowhead" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#666"></path>
+    </marker>
+    <!-- Gradient for final HDR tile -->
+    <linearGradient id="mergeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fff"></stop>
+      <stop offset="100%" stop-color="#777"></stop>
+    </linearGradient>
+  </defs>
+
+  <!-- Bottom row: three exposure tiles -->
+  <rect x="8" y="44" width="10" height="10" fill="#444" rx="2"></rect>
+  <rect x="27" y="44" width="10" height="10" fill="#aaa" rx="2"></rect>
+  <rect x="46" y="44" width="10" height="10" fill="#eee" rx="2"></rect>
+
+  <!-- Arrows pointing up toward the merge point -->
+  <line x1="13" y1="44" x2="32" y2="28" stroke="#666" stroke-width="2" marker-end="url(#arrowhead)"></line>
+  <line x1="32" y1="44" x2="32" y2="28" stroke="#666" stroke-width="2" marker-end="url(#arrowhead)"></line>
+  <line x1="51" y1="44" x2="32" y2="28" stroke="#666" stroke-width="2" marker-end="url(#arrowhead)"></line>
+
+  <!-- Top: combined HDR tile -->
+  <rect x="22" y="14" width="20" height="20" fill="url(#mergeGrad)" stroke="#666" stroke-width="2" rx="3"></rect>
+</svg>


### PR DESCRIPTION
## Summary
- use the new `favicon2.svg` as the Next.js app icon

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d714e1c30832ab1a912647a2ab1a0