### PR TITLE
Add temporary storage disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ NEXT_PUBLIC_BASE_PATH=/hdr npm run dev
 ```
 
 Processed images are stored in `frontend/public/downloads` and can be retrieved
-via `/api/downloads/<file>`.
+via `/api/downloads/<file>`. Files older than 1 day are automatically deleted
+from this directory.
 
 Open `http://localhost:3000` in your browser and use the **Import Images** button to select your AEB files. Imported files are hashed client-side so similar photos are grouped together. Each group shows a **Create HDR** button to merge that set, and there's also a **Create All** button to process every group at once.
 

--- a/frontend/app/api/downloads/[file]/route.ts
+++ b/frontend/app/api/downloads/[file]/route.ts
@@ -2,10 +2,33 @@ import { NextResponse } from 'next/server';
 import { join } from 'path';
 import { promises as fs } from 'fs';
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function cleanupOldDownloads(dir: string) {
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    const now = Date.now();
+    await Promise.all(
+      entries
+        .filter((e) => e.isFile())
+        .map(async (e) => {
+          const p = join(dir, e.name);
+          const stat = await fs.stat(p);
+          if (now - stat.mtimeMs > DAY_MS) {
+            await fs.unlink(p);
+          }
+        })
+    );
+  } catch {
+    /* ignore errors */
+  }
+}
+
 export async function GET(req: Request) {
   const { pathname } = new URL(req.url);
   const file = pathname.split('/').pop() || '';
   const filePath = join(process.cwd(), 'public', 'downloads', file);
+  await cleanupOldDownloads(join(process.cwd(), 'public', 'downloads'));
   try {
     const data = await fs.readFile(filePath);
     return new NextResponse(data, {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -570,6 +570,10 @@ export default function Home() {
           <img src={fullscreenUrl} className="max-w-full max-h-full" />
         </div>
       )}
+      <p className="text-xs text-gray-600 mt-4">
+        Uploaded images are stored on the server for up to 1 day and are then
+        automatically deleted.
+      </p>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- cleanup processed images more than a day old
- show a disclaimer about temporary storage in the web UI
- note automatic deletion in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d75d562bc832a9056995eea88d5bd