### PR TITLE
Add tone mapping options to web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ via `/api/downloads/<file>`. Files older than 1 day are automatically deleted
 from this directory.
 
 Open `http://localhost:3000` in your browser and use the **Import Images** button to select your AEB files. Imported files are hashed client-side so similar photos are grouped together. Each group shows a **Create HDR** button to merge that set, and there's also a **Create All** button to process every group at once.
+The settings panel now lets you choose the tone mapping algorithm via radio buttons, offering *Mantiuk*, *Reinhard* and *Drago* options.
 
 ### Docker
 

--- a/frontend/app/api/process/route.ts
+++ b/frontend/app/api/process/route.ts
@@ -38,6 +38,7 @@ export async function POST(req: Request) {
   const antiGhost = formData.get('antiGhost') === '1';
   const contrast = formData.get('contrast');
   const saturation = formData.get('saturation');
+  const algorithm = formData.get('algorithm');
   const dir = await fs.mkdtemp(join(tmpdir(), 'hdr-'));
   const paths: string[] = [];
   for (const file of files) {
@@ -63,6 +64,7 @@ export async function POST(req: Request) {
   if (antiGhost) args.push('--deghost');
   if (contrast) args.push('--contrast', String(contrast));
   if (saturation) args.push('--saturation', String(saturation));
+  if (algorithm) args.push('--algorithm', String(algorithm));
 
   const { readable, writable } = new TransformStream();
   const writer = writable.getWriter();


### PR DESCRIPTION
## Summary
- expose tone mapping algorithm in settings
- adjust API route to forward algorithm argument
- toggle settings via button without drop-down arrow
- update documentation

## Testing
- `npm --prefix frontend run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d7f1f8ea8832ab36348426c84e29f