### PR TITLE
Add icon-based status indicator

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -11,6 +11,10 @@ import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
+import AutorenewIcon from "@mui/icons-material/Autorenew";
 
 // Prefix API requests and returned download URLs when the application is served
 // behind a reverse proxy. The value is injected at build time via the
@@ -47,6 +51,27 @@ export default function Home() {
   const [fullscreenUrl, setFullscreenUrl] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState<Record<number, boolean>>({});
   const processingRef = useRef(false);
+
+  const statusIcon = (status?: Group["status"]) => {
+    switch (status) {
+      case "queued":
+        return <HourglassEmptyIcon fontSize="small" color="action" />;
+      case "processing":
+        return (
+          <AutorenewIcon
+            fontSize="small"
+            color="primary"
+            className="animate-spin"
+          />
+        );
+      case "done":
+        return <CheckCircleIcon fontSize="small" color="success" />;
+      case "error":
+        return <ErrorIcon fontSize="small" color="error" />;
+      default:
+        return null;
+    }
+  };
 
   const resetURLs = (gs: Group[]) => {
     gs.forEach((g) => {
@@ -423,7 +448,10 @@ export default function Home() {
       {groups.length === 1 && (
         <div className="w-full max-w-2xl grid gap-4">
           <div className="grid md:grid-cols-2 gap-4">
-            <Paper className="p-4 flex flex-col gap-4" elevation={3}>
+            <Paper className="relative p-4 flex flex-col gap-4" elevation={3}>
+              <div className="absolute top-2 right-2">
+                {statusIcon(groups[0].status)}
+              </div>
               <div className="grid grid-cols-3 gap-2">
                 {groups[0].urls.map((src) => (
                   <img key={src} src={src} className="w-24 h-24 object-cover rounded-lg" />
@@ -454,17 +482,12 @@ export default function Home() {
                       "Create HDR"
                     )}
                   </Button>
-                  {groups[0].status && groups[0].status !== "idle" && (
-                    <>
-                      <p className="text-sm">Status: {groups[0].status}</p>
-                      {groups[0].status === "processing" && (
-                        <LinearProgress
-                          sx={{ mt: 1 }}
-                          variant="determinate"
-                          value={groups[0].progress ?? 0}
-                        />
-                      )}
-                    </>
+                  {groups[0].status === "processing" && (
+                    <LinearProgress
+                      sx={{ mt: 1 }}
+                      variant="determinate"
+                      value={groups[0].progress ?? 0}
+                    />
                   )}
                 </div>
               </div>
@@ -500,7 +523,8 @@ export default function Home() {
       {groups.length > 1 && (
         <div className="w-full max-w-3xl grid gap-4 md:grid-cols-2">
           {groups.map((g, idx) => (
-            <Paper key={idx} variant="outlined" className="p-4 flex flex-col gap-4">
+            <Paper key={idx} variant="outlined" className="relative p-4 flex flex-col gap-4">
+              <div className="absolute top-2 right-2">{statusIcon(g.status)}</div>
               <h3 className="text-sm font-semibold mb-2">Group {idx + 1}</h3>
               <div className="grid md:grid-cols-2 gap-4 flex-grow">
                 <div className="grid gap-4">
@@ -554,17 +578,12 @@ export default function Home() {
                       "Create HDR"
                     )}
                   </Button>
-                  {g.status && g.status !== "idle" && (
-                    <>
-                      <p className="text-xs">Status: {g.status}</p>
-                      {g.status === "processing" && (
-                        <LinearProgress
-                          sx={{ mt: 1 }}
-                          variant="determinate"
-                          value={g.progress ?? 0}
-                        />
-                      )}
-                    </>
+                  {g.status === "processing" && (
+                    <LinearProgress
+                      sx={{ mt: 1 }}
+                      variant="determinate"
+                      value={g.progress ?? 0}
+                    />
                   )}
                 </div>
               </div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
+        "@mui/icons-material": "^5.15.17",
         "@mui/material": "^5.15.17",
         "next": "15.3.5",
         "react": "^19.0.0",
@@ -800,6 +801,32 @@
         "url": "https://opencollective.com/mui-org"
       }
     },
+    "node_modules/@mui/icons-material": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.18.0.tgz",
+      "integrity": "sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/material": {
       "version": "5.17.1",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.17.1.tgz",
@@ -1374,6 +1401,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "react-dom": "^19.0.0",
   "next": "15.3.5"
   ,"@mui/material": "^5.15.17",
+  "@mui/icons-material": "^5.15.17",
   "@emotion/react": "^11.11.4",
   "@emotion/styled": "^11.11.5"
   },


### PR DESCRIPTION
## Summary
- show group status with icons instead of text
- display status icons in the top-right corner of each group card
- add Material UI icons dependency

## Testing
- `npm install --package-lock-only`
- `pytest -q` *(fails: ModuleNotFoundError for cv2 and numpy)*

------
https://chatgpt.com/codex/tasks/task_e_686d8226bf0c832a836250c1ed4ff7f2