### PR TITLE
Show latest HDR result only

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -175,7 +175,7 @@ export default function Home() {
         const name =
           groups.length === 1 && g.results.length === 1
             ? "hdr_result.jpg"
-            : `hdr_group_${idx + 1}_${j + 1}.jpg`;
+            : `hdr_batch_${idx + 1}_${j + 1}.jpg`;
         triggerDownload(r.url, name);
       });
     });
@@ -471,7 +471,7 @@ export default function Home() {
             {queue.map((item, i) => (
               <ListItem key={i} sx={{ display: "block" }}>
                 <ListItemText
-                  primary={`Group ${item.index + 1} (${item.settings.algorithm})`}
+                  primary={`Batch ${item.index + 1} (${item.settings.algorithm})`}
                   secondary={groups[item.index].status}
                 />
                 {i === 0 && groups[item.index].status === "processing" && (
@@ -496,7 +496,7 @@ export default function Home() {
               </div>
               <div className="grid grid-cols-3 gap-2">
                 {groups[0].urls.map((src) => (
-                  <img key={src} src={src} className="w-24 h-24 object-cover rounded-lg" />
+                  <img key={src} src={src} className="w-16 h-16 object-cover rounded-lg" />
                 ))}
               </div>
               <div className="mt-auto pt-2 border-t border-gray-300 flex items-start justify-between gap-2">
@@ -536,19 +536,22 @@ export default function Home() {
             </Paper>
             {groups[0].results.length > 0 && (
               <div className="flex flex-wrap gap-2">
-                {groups[0].results.map((r, i) => (
-                  <Paper key={i} className="flex flex-col items-center gap-2 p-2" elevation={3}>
-                    <Typography variant="subtitle2">HDR Result {i + 1}</Typography>
-                    <img
-                      src={r.url}
-                      className="w-48 h-48 object-cover rounded-lg cursor-pointer"
-                      onClick={() => setSelectedIndex(allResults.indexOf(r))}
-                    />
-                    <a href={r.url} download={`hdr_result_${i + 1}.jpg`}>
-                      <Button variant="outlined" color="secondary" size="small">Download</Button>
-                    </a>
-                  </Paper>
-                ))}
+                {(() => {
+                  const r = groups[0].results[groups[0].results.length - 1];
+                  return r ? (
+                    <Paper className="flex flex-col items-center gap-2 p-2" elevation={3}>
+                      <Typography variant="subtitle2">HDR Result {groups[0].results.length}</Typography>
+                      <img
+                        src={r.url}
+                        className="w-48 h-48 object-cover rounded-lg cursor-pointer"
+                        onClick={() => setSelectedIndex(allResults.indexOf(r))}
+                      />
+                      <a href={r.url} download={`hdr_result_${groups[0].results.length}.jpg`}>
+                        <Button variant="outlined" color="secondary" size="small">Download</Button>
+                      </a>
+                    </Paper>
+                  ) : null;
+                })()}
               </div>
             )}
           </div>
@@ -567,30 +570,33 @@ export default function Home() {
           {groups.map((g, idx) => (
             <Paper key={idx} variant="outlined" className="relative p-4 flex flex-col gap-4">
               <div className="absolute top-2 right-2">{statusIcon(g.status)}</div>
-              <h3 className="text-sm font-semibold mb-2">Group {idx + 1}</h3>
+              <h3 className="text-sm font-semibold mb-2">Batch {idx + 1}</h3>
               <div className="grid md:grid-cols-2 gap-4 flex-grow">
                 <div className="grid gap-4">
                   <div className="grid grid-cols-3 gap-2">
                     {g.urls.map((src) => (
-                      <img key={src} src={src} className="w-24 h-24 object-cover rounded-lg" />
+                      <img key={src} src={src} className="w-16 h-16 object-cover rounded-lg" />
                     ))}
                   </div>
                 </div>
                 {g.results.length > 0 && (
                   <div className="flex flex-col gap-2">
-                    {g.results.map((r, j) => (
-                      <Paper key={j} className="flex flex-col items-center gap-2 p-2" elevation={3}>
-                        <Typography variant="subtitle2">HDR Result {j + 1}</Typography>
-                        <img
-                          src={r.url}
-                          className="w-48 h-48 object-cover rounded-lg cursor-pointer"
-                          onClick={() => setSelectedIndex(allResults.indexOf(r))}
-                        />
-                        <a href={r.url} download={`hdr_group_${idx + 1}_${j + 1}.jpg`}>
-                          <Button size="small" variant="outlined" color="secondary">Download</Button>
-                        </a>
-                      </Paper>
-                    ))}
+                    {(() => {
+                      const r = g.results[g.results.length - 1];
+                      return r ? (
+                        <Paper className="flex flex-col items-center gap-2 p-2" elevation={3}>
+                          <Typography variant="subtitle2">HDR Result {g.results.length}</Typography>
+                          <img
+                            src={r.url}
+                            className="w-48 h-48 object-cover rounded-lg cursor-pointer"
+                            onClick={() => setSelectedIndex(allResults.indexOf(r))}
+                          />
+                          <a href={r.url} download={`hdr_batch_${idx + 1}_${g.results.length}.jpg`}>
+                            <Button size="small" variant="outlined" color="secondary">Download</Button>
+                          </a>
+                        </Paper>
+                      ) : null;
+                    })()}
                   </div>
                 )}
               </div>
@@ -651,7 +657,7 @@ export default function Home() {
               <img
                 key={i}
                 src={r.url}
-                className="h-24 w-24 object-cover rounded-lg cursor-pointer"
+                className="h-16 w-16 object-cover rounded-lg cursor-pointer"
                 onClick={() => setSelectedIndex(i)}
               />
             ))}


### PR DESCRIPTION
## Summary
- minimize thumbnails in cards
- show only the most recent HDR result on each card
- rename UI from 'Group' to 'Batch'

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_686d8bf9df90832aa3c38e24155ff675