### PR TITLE
Fix highlight clipping after tone mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ output/
 
 frontend/node_modules/
 frontend/.next/
+__pycache__/
+tests/__pycache__/
+.pytest_cache/

--- a/hdr_utils.py
+++ b/hdr_utils.py
@@ -74,7 +74,11 @@ def tonemap(
     ldr = np.clip(ldr * brightness, 0.0, 1.0)
     ldr = np.nan_to_num(ldr, nan=0.0, posinf=1.0, neginf=0.0)
     ldr_8bit = np.clip(ldr * 255, 0, 255).astype("uint8")
-    return enhance_image(ldr_8bit, reference_image)
+
+    enhanced = enhance_image(ldr_8bit, reference_image)
+    highlight_mask = ldr_8bit.max(axis=2) >= 250
+    enhanced[highlight_mask] = [255, 255, 255]
+    return enhanced
 
 
 def tonemap_mantiuk(

--- a/tests/test_highlight_issue.py
+++ b/tests/test_highlight_issue.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+import numpy as np
+import cv2
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT.parent))
+
+from HDR_Compositor.find_and_merge_aeb import create_hdr
+from HDR_Compositor.hdr_utils import tonemap_mantiuk
+
+
+def test_reference_highlight_preserved():
+    imgs = []
+    vals = [40, 80, 160]
+    for i, val in enumerate(vals):
+        img = np.full((2, 2, 3), val, dtype=np.uint8)
+        if i == 0:
+            img[0, 0] = [255, 255, 255]
+        imgs.append(img)
+    times = [1.0, 0.5, 0.25]
+    hdr = create_hdr(imgs, times)
+    ref = imgs[1]
+    ldr = tonemap_mantiuk(hdr, ref)
+    assert ldr[0, 0].mean() >= 250


### PR DESCRIPTION
## Summary
- preserve white highlights during tonemapping
- ignore Python cache files
- cover regression with test for highlight preservation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d9bdb62bc832aa3f0bd55af111ba2