### PR TITLE
Fix highlight loss in tone mapping

### DIFF
--- a/hdr_utils.py
+++ b/hdr_utils.py
@@ -71,6 +71,9 @@ def tonemap(
         raise ValueError(f"Unknown tonemapping algorithm: {algorithm}")
 
     ldr = tonemap_op.process(hdr_norm.copy())
+    ldr_max = float(ldr.max())
+    if ldr_max > 0 and ldr_max < 0.99:
+        ldr /= ldr_max
     ldr = np.clip(ldr * brightness, 0.0, 1.0)
     ldr = np.nan_to_num(ldr, nan=0.0, posinf=1.0, neginf=0.0)
     ldr_8bit = np.clip(ldr * 255, 0, 255).astype("uint8")

--- a/tests/test_hdr_utils.py
+++ b/tests/test_hdr_utils.py
@@ -25,9 +25,9 @@ def test_get_medium_exposure_image():
 
 
 def test_enhance_and_tonemap():
-    base = np.arange(16*3, dtype=np.uint8).reshape(4, 4, 3)
+    base = np.arange(16 * 3, dtype=np.uint8).reshape(4, 4, 3)
     images = [base, base + 20, base + 40]
-    times = [1/30, 1/60, 1/125]
+    times = [1 / 30, 1 / 60, 1 / 125]
     hdr = create_hdr(images, times)
     ldr = tonemap_mantiuk(hdr)
     assert ldr.dtype == np.uint8
@@ -63,7 +63,7 @@ def test_tonemap_preserves_highlights():
     hdr = create_hdr(images, times)
     ldr = tonemap_mantiuk(hdr)
     # Top-left pixel corresponds to the bright spot in all exposures
-    assert ldr[0, 0].mean() > 200
+    assert ldr[0, 0].mean() >= 250
 
 
 def test_tonemap_gamma_brightness():


### PR DESCRIPTION
## Summary
- preserve maximum brightness while tone mapping HDR images
- update test to demand nearly-white highlights

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d9bdb62bc832aa3f0bd55af111ba2