### PR TITLE
Fix overexposed highlights

### DIFF
--- a/hdr_utils.py
+++ b/hdr_utils.py
@@ -79,8 +79,11 @@ def tonemap(
     ldr_8bit = np.clip(ldr * 255, 0, 255).astype("uint8")
 
     enhanced = enhance_image(ldr_8bit, reference_image)
-    highlight_mask = ldr_8bit.max(axis=2) >= 250
-    enhanced[highlight_mask] = [255, 255, 255]
+    highlight_mask = ldr_8bit.max(axis=2) >= 240
+    if np.any(highlight_mask):
+        kernel = np.ones((3, 3), np.uint8)
+        highlight_mask = cv2.dilate(highlight_mask.astype(np.uint8), kernel, iterations=1) > 0
+        enhanced[highlight_mask] = [255, 255, 255]
     return enhanced
 
 

--- a/tests/test_highlight_issue.py
+++ b/tests/test_highlight_issue.py
@@ -23,3 +23,21 @@ def test_reference_highlight_preserved():
     ref = imgs[1]
     ldr = tonemap_mantiuk(hdr, ref)
     assert ldr[0, 0].mean() >= 250
+
+
+def test_large_bright_area_preserved():
+    imgs = []
+    vals = [40, 80, 160]
+    for i, val in enumerate(vals):
+        img = np.full((8, 8, 3), val, dtype=np.uint8)
+        if i == 0:
+            cv2.circle(img, (4, 4), 2, (255, 255, 255), -1)
+        imgs.append(img)
+    times = [1.0, 0.5, 0.25]
+    hdr = create_hdr(imgs, times)
+    ref = imgs[1]
+    ldr = tonemap_mantiuk(hdr, ref)
+    center = ldr[4, 4].mean()
+    neighbour = ldr[4, 3].mean()
+    assert center >= 250
+    assert neighbour >= 250


### PR DESCRIPTION
## Summary
- keep large highlights white by dilating the highlight mask
- add regression test for preserving larger highlight areas

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e3d49a824832ab979eb5bfe5f8f75