### PR TITLE
Add instructions for building executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run gui
+.PHONY: run gui package-linux package-windows
 
 run:
 	docker build -f Dockerfile.web -t hdr-webapp .
@@ -9,6 +9,14 @@ run:
 
 # Launch the desktop HDR compositor GUI
 gui:
-	python hdr_gui.py
+        python hdr_gui.py
+
+# Build a standalone binary for Linux using PyInstaller
+package-linux:
+        pyinstaller --onefile hdr_gui.py --name hdr_compositor
+
+# Display Windows packaging instructions
+package-windows:
+        @echo "Run 'pyinstaller --onefile hdr_gui.py --name hdr_compositor' on a Windows machine"
 
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,36 @@ pip install -r requirements.txt
 
 The tools rely on `opencv-python-headless`, `numpy` and `dearpygui` in addition to `exiftool`. On Debian based systems you can install exiftool with `apt-get install exiftool`.
 
+### Building Executables
+
+Self-contained binaries of the desktop GUI can be created with [PyInstaller](https://www.pyinstaller.org/).
+
+Install PyInstaller:
+
+```bash
+pip install pyinstaller
+```
+
+#### Linux
+
+Run the following command to produce a standalone executable:
+
+```bash
+pyinstaller --onefile hdr_gui.py --name hdr_compositor
+```
+
+The binary `dist/hdr_compositor` can then be executed directly.
+
+#### Windows
+
+PyInstaller does not cross compile, so building a Windows executable requires running the command on a Windows system:
+
+```bash
+pyinstaller --onefile hdr_gui.py --name hdr_compositor
+```
+
+This creates `dist/hdr_compositor.exe` which launches the GUI without needing Python installed.
+
 ### Release Process
 
 Tagged commits with names starting with `v` trigger an automated workflow.


### PR DESCRIPTION
## Summary
- document how to package the GUI with PyInstaller
- add Makefile targets for Linux and Windows packaging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ee20102e4832aaf5d869a2711bf60